### PR TITLE
archive.ApplyLayer() - handle directory whiteouts

### DIFF
--- a/archive/diff.go
+++ b/archive/diff.go
@@ -20,6 +20,11 @@ func ApplyLayer(dest string, layer Archive) error {
 	// Step 2: walk for whiteouts and apply them, removing them in the process
 	err := filepath.Walk(dest, func(fullPath string, f os.FileInfo, err error) error {
 		if err != nil {
+			if os.IsNotExist(err) {
+				// This happens in the case of whiteouts in parent dir removing a directory
+				// We just ignore it
+				return filepath.SkipDir
+			}
 			return err
 		}
 


### PR DESCRIPTION
When directories are white-outed we can get called with the previously
removed directories. Handle this with os.IsNotExist(error).
