### PR TITLE
Implement fallback operation for driver.Diff()

### DIFF
--- a/container.go
+++ b/container.go
@@ -1382,7 +1382,8 @@ func (container *Container) ExportRw() (archive.Archive, error) {
 	if container.runtime == nil {
 		return nil, fmt.Errorf("Can't load storage driver for unregistered container %s", container.ID)
 	}
-	return container.runtime.driver.Diff(container.ID)
+
+	return container.runtime.Diff(container)
 }
 
 func (container *Container) Export() (archive.Archive, error) {

--- a/devmapper/driver.go
+++ b/devmapper/driver.go
@@ -2,7 +2,6 @@ package devmapper
 
 import (
 	"fmt"
-	"github.com/dotcloud/docker/archive"
 	"github.com/dotcloud/docker/graphdriver"
 	"os"
 	"path"
@@ -55,10 +54,6 @@ func (d *Driver) Get(id string) (string, error) {
 		return "", err
 	}
 	return mp, nil
-}
-
-func (d *Driver) Diff(id string) (archive.Archive, error) {
-	return nil, fmt.Errorf("Not implemented")
 }
 
 func (d *Driver) DiffSize(id string) (int64, error) {

--- a/graphdriver/driver.go
+++ b/graphdriver/driver.go
@@ -16,7 +16,6 @@ type Driver interface {
 
 	Get(id string) (dir string, err error)
 
-	Diff(id string) (archive.Archive, error)
 	DiffSize(id string) (bytes int64, err error)
 
 	Cleanup() error
@@ -24,6 +23,10 @@ type Driver interface {
 
 type Changer interface {
 	Changes(id string) ([]archive.Change, error)
+}
+
+type Differ interface {
+	Diff(id string) (archive.Archive, error)
 }
 
 var (

--- a/graphdriver/dummy/driver.go
+++ b/graphdriver/dummy/driver.go
@@ -73,14 +73,6 @@ func (d *Driver) Get(id string) (string, error) {
 	return dir, nil
 }
 
-func (d *Driver) Diff(id string) (archive.Archive, error) {
-	p, err := d.Get(id)
-	if err != nil {
-		return nil, err
-	}
-	return archive.Tar(p, archive.Uncompressed)
-}
-
 func (d *Driver) DiffSize(id string) (int64, error) {
 	return -1, fmt.Errorf("Not implemented")
 }


### PR DESCRIPTION
This moves the Diff() operation to a separate Differ interface and
implements a fallback that uses the Changes() results to encode
a diff tar.
