### PR TITLE
Dm plugin status

### DIFF
--- a/api_params.go
+++ b/api_params.go
@@ -52,6 +52,7 @@ type APIInfo struct {
 	Debug              bool
 	Containers         int
 	Images             int
+	Driver             string `json:",omitempty"`
 	NFd                int    `json:",omitempty"`
 	NGoroutines        int    `json:",omitempty"`
 	MemoryLimit        bool   `json:",omitempty"`

--- a/api_params.go
+++ b/api_params.go
@@ -52,16 +52,17 @@ type APIInfo struct {
 	Debug              bool
 	Containers         int
 	Images             int
-	Driver             string `json:",omitempty"`
-	NFd                int    `json:",omitempty"`
-	NGoroutines        int    `json:",omitempty"`
-	MemoryLimit        bool   `json:",omitempty"`
-	SwapLimit          bool   `json:",omitempty"`
-	IPv4Forwarding     bool   `json:",omitempty"`
-	LXCVersion         string `json:",omitempty"`
-	NEventsListener    int    `json:",omitempty"`
-	KernelVersion      string `json:",omitempty"`
-	IndexServerAddress string `json:",omitempty"`
+	Driver             string      `json:",omitempty"`
+	DriverStatus       [][2]string `json:",omitempty"`
+	NFd                int         `json:",omitempty"`
+	NGoroutines        int         `json:",omitempty"`
+	MemoryLimit        bool        `json:",omitempty"`
+	SwapLimit          bool        `json:",omitempty"`
+	IPv4Forwarding     bool        `json:",omitempty"`
+	LXCVersion         string      `json:",omitempty"`
+	NEventsListener    int         `json:",omitempty"`
+	KernelVersion      string      `json:",omitempty"`
+	IndexServerAddress string      `json:",omitempty"`
 }
 
 type APITop struct {

--- a/aufs/aufs.go
+++ b/aufs/aufs.go
@@ -103,6 +103,10 @@ func (a *AufsDriver) String() string {
 	return "aufs"
 }
 
+func (d *AufsDriver) Status() [][2]string {
+	return nil
+}
+
 // Three folders are created for each id
 // mnt, layers, and diff
 func (a *AufsDriver) Create(id, parent string) error {

--- a/commands.go
+++ b/commands.go
@@ -460,6 +460,7 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 
 	fmt.Fprintf(cli.out, "Containers: %d\n", out.Containers)
 	fmt.Fprintf(cli.out, "Images: %d\n", out.Images)
+	fmt.Fprintf(cli.out, "Driver: %s\n", out.Driver)
 	if out.Debug || os.Getenv("DEBUG") != "" {
 		fmt.Fprintf(cli.out, "Debug mode (server): %v\n", out.Debug)
 		fmt.Fprintf(cli.out, "Debug mode (client): %v\n", os.Getenv("DEBUG") != "")

--- a/commands.go
+++ b/commands.go
@@ -461,6 +461,9 @@ func (cli *DockerCli) CmdInfo(args ...string) error {
 	fmt.Fprintf(cli.out, "Containers: %d\n", out.Containers)
 	fmt.Fprintf(cli.out, "Images: %d\n", out.Images)
 	fmt.Fprintf(cli.out, "Driver: %s\n", out.Driver)
+	for _, pair := range out.DriverStatus {
+		fmt.Fprintf(cli.out, " %s: %s\n", pair[0], pair[1])
+	}
 	if out.Debug || os.Getenv("DEBUG") != "" {
 		fmt.Fprintf(cli.out, "Debug mode (server): %v\n", out.Debug)
 		fmt.Fprintf(cli.out, "Debug mode (client): %v\n", os.Getenv("DEBUG") != "")

--- a/devmapper/driver.go
+++ b/devmapper/driver.go
@@ -37,6 +37,21 @@ func (d *Driver) String() string {
 	return "devicemapper"
 }
 
+func (d *Driver) Status() [][2]string {
+	s := d.DeviceSet.Status()
+
+	status := [][2]string{
+		{"Pool Name", s.PoolName},
+		{"Data file", s.DataLoopback},
+		{"Metadata file", s.MetadataLoopback},
+		{"Data Space Used", fmt.Sprintf("%.1f Mb", float64(s.Data.Used)/(1024*1024))},
+		{"Data Space Total", fmt.Sprintf("%.1f Mb", float64(s.Data.Total)/(1024*1024))},
+		{"Metadata Space Used", fmt.Sprintf("%.1f Mb", float64(s.Metadata.Used)/(1024*1024))},
+		{"Metadata Space Total", fmt.Sprintf("%.1f Mb", float64(s.Metadata.Total)/(1024*1024))},
+	}
+	return status
+}
+
 func (d *Driver) Cleanup() error {
 	return d.DeviceSet.Shutdown()
 }

--- a/graphdriver/driver.go
+++ b/graphdriver/driver.go
@@ -11,6 +11,8 @@ import (
 type InitFunc func(root string) (Driver, error)
 
 type Driver interface {
+	String() string
+
 	Create(id, parent string) error
 	Remove(id string) error
 

--- a/graphdriver/driver.go
+++ b/graphdriver/driver.go
@@ -19,6 +19,8 @@ type Driver interface {
 	Get(id string) (dir string, err error)
 	Size(id string) (bytes int64, err error)
 
+	Status() [][2]string
+
 	Cleanup() error
 }
 

--- a/graphdriver/dummy/driver.go
+++ b/graphdriver/dummy/driver.go
@@ -27,6 +27,10 @@ func (d *Driver) String() string {
 	return "dummy"
 }
 
+func (d *Driver) Status() [][2]string {
+	return nil
+}
+
 func (d *Driver) Cleanup() error {
 	return nil
 }

--- a/server.go
+++ b/server.go
@@ -375,6 +375,7 @@ func (srv *Server) DockerInfo() *APIInfo {
 	return &APIInfo{
 		Containers:         len(srv.runtime.List()),
 		Images:             imgcount,
+		Driver:             srv.runtime.driver.String(),
 		MemoryLimit:        srv.runtime.capabilities.MemoryLimit,
 		SwapLimit:          srv.runtime.capabilities.SwapLimit,
 		IPv4Forwarding:     !srv.runtime.capabilities.IPv4ForwardingDisabled,

--- a/server.go
+++ b/server.go
@@ -376,6 +376,7 @@ func (srv *Server) DockerInfo() *APIInfo {
 		Containers:         len(srv.runtime.List()),
 		Images:             imgcount,
 		Driver:             srv.runtime.driver.String(),
+		DriverStatus:       srv.runtime.driver.Status(),
 		MemoryLimit:        srv.runtime.capabilities.MemoryLimit,
 		SwapLimit:          srv.runtime.capabilities.SwapLimit,
 		IPv4Forwarding:     !srv.runtime.capabilities.IPv4ForwardingDisabled,


### PR DESCRIPTION
Add driver name and status details to docker info output

Here is some example output:

```
# docker info
Containers: 7
Images: 9
Driver: devicemapper
 Pool Name: docker-0:31-15505662-pool
 Data file: /var/lib/docker/devicemapper/devicemapper/data
 Metadata file: /var/lib/docker/devicemapper/devicemapper/metadata
 Data Space Used: 2405.4 Mb
 Data Space Total: 102400.0 Mb
 Metadata Space Used: 2.3 Mb
 Metadata Space Total: 2048.0 Mb
Debug mode (server): true
Debug mode (client): false
Fds: 11
Goroutines: 11
LXC Version: 0.8.0
EventsListeners: 0
Kernel Version: 3.11.4-300.1.fc20.x86_64
```
