### PR TITLE
Use dummy driver for volumes

### DIFF
--- a/graphdriver/driver.go
+++ b/graphdriver/driver.go
@@ -50,7 +50,7 @@ func Register(name string, initFunc InitFunc) error {
 	return nil
 }
 
-func getDriver(name, home string) (Driver, error) {
+func GetDriver(name, home string) (Driver, error) {
 	if initFunc, exists := drivers[name]; exists {
 		return initFunc(path.Join(home, name))
 	}
@@ -62,11 +62,11 @@ func New(root string) (Driver, error) {
 	var lastError error
 	// Use environment variable DOCKER_DRIVER to force a choice of driver
 	if name := os.Getenv("DOCKER_DRIVER"); name != "" {
-		return getDriver(name, root)
+		return GetDriver(name, root)
 	}
 	// Check for priority drivers first
 	for _, name := range priority {
-		driver, lastError = getDriver(name, root)
+		driver, lastError = GetDriver(name, root)
 		if lastError != nil {
 			utils.Debugf("Error loading driver %s: %s", name, lastError)
 			continue

--- a/runtime.go
+++ b/runtime.go
@@ -629,7 +629,14 @@ func NewRuntimeFromDirectory(config *DaemonConfig) (*Runtime, error) {
 	if err != nil {
 		return nil, err
 	}
-	volumes, err := NewGraph(path.Join(config.Root, "volumes"), driver)
+
+	// We don't want to use a complex driver like aufs or devmapper
+	// for volumes, just a plain filesystem
+	volumesDriver, err := graphdriver.GetDriver("dummy", config.Root)
+	if err != nil {
+		return nil, err
+	}
+	volumes, err := NewGraph(path.Join(config.Root, "volumes"), volumesDriver)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
It makes no sense to use the aufs or devicemapper drivers for volumes.
The aufs one is perhaps not a big problem, but the devicemapper one
certainly is. It will be unnecessarily using a dm
blockdevice-over-loopback with a limited size base FS.

This just hardcodes the driver to be the dummy, perhaps in the future
we can have other drivers that make sense for the volumes.
