### PR TITLE
Support capabilities bits in xattrs in layers

### DIFF
--- a/archive/archive.go
+++ b/archive/archive.go
@@ -110,7 +110,7 @@ func escapeName(name string) string {
 // Tar creates an archive from the directory at `path`, only including files whose relative
 // paths are included in `filter`. If `filter` is nil, then all files are included.
 func TarFilter(path string, options *TarOptions) (io.Reader, error) {
-	args := []string{"tar", "--numeric-owner", "-f", "-", "-C", path, "-T", "-"}
+	args := []string{"tar", "--numeric-owner", "--xattrs", "-f", "-", "-C", path, "-T", "-"}
 	if options.Includes == nil {
 		options.Includes = []string{"."}
 	}
@@ -188,7 +188,7 @@ func Untar(archive io.Reader, path string, options *TarOptions) error {
 	compression := DetectCompression(buf)
 
 	utils.Debugf("Archive compression detected: %s", compression.Extension())
-	args := []string{"--numeric-owner", "-f", "-", "-C", path, "-x" + compression.Flag()}
+	args := []string{"--numeric-owner", "--xattrs", "--xattrs-include=security.capability", "-f", "-", "-C", path, "-x" + compression.Flag()}
 
 	if options != nil {
 		for _, exclude := range options.Excludes {


### PR DESCRIPTION
This adds support for detecting changes in the security.capability xattr, and enables the right flag in the tar commands to store/extract it.

This is needed for docker to work well with fedora packages. For instance, the Fedora httpd package has a /usr/sbin/suexec that has a capabilities bit set instead of being setuid. I verified this patchset by doing:

```
docker run -t -i mattdm/fedora bash
yum install -y httpd attr
bash-4.2# attr -l /usr/sbin/suexec 
Attribute "selinux" has a 32 byte value for /usr/sbin/suexec
Attribute "capability" has a 20 byte value for /usr/sbin/suexec
exit
docker commit ID
docker run -t -i ID bash
bash-4.2# attr -l /usr/sbin/suexec 
Attribute "selinux" has a 32 byte value for /usr/sbin/suexec
Attribute "capability" has a 20 byte value for /usr/sbin/suexec
```
