### PR TITLE
Save driver to container and skip incompat containers

### DIFF
--- a/container.go
+++ b/container.go
@@ -47,6 +47,7 @@ type Container struct {
 	HostnamePath   string
 	HostsPath      string
 	Name           string
+	Driver         string
 
 	cmd       *exec.Cmd
 	stdout    *utils.WriteBroadcaster


### PR DESCRIPTION
For people who toggle drivers we want to save the driver used
to create a container so that if the driver changes we can skip
loading the container and it should not show up in docker ps
