### PR TITLE
devmapper: Use a "root" subdirectory in the devmapper volume

### DIFF
--- a/graphdriver/devmapper/driver.go
+++ b/graphdriver/devmapper/driver.go
@@ -3,6 +3,7 @@ package devmapper
 import (
 	"fmt"
 	"github.com/dotcloud/docker/graphdriver"
+	"io/ioutil"
 	"os"
 	"path"
 )
@@ -57,7 +58,26 @@ func (d *Driver) Cleanup() error {
 }
 
 func (d *Driver) Create(id string, parent string) error {
-	return d.DeviceSet.AddDevice(id, parent)
+	if err := d.DeviceSet.AddDevice(id, parent); err != nil {
+		return err
+	}
+
+	mp := path.Join(d.home, "mnt", id)
+	if err := d.mount(id, mp); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(path.Join(mp, "rootfs"), 0755); err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	// Create an "id" file with the container/image id in it to help reconscruct this in case
+	// of later problems
+	if err := ioutil.WriteFile(path.Join(mp, "id"), []byte(id), 0600); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (d *Driver) Remove(id string) error {
@@ -69,7 +89,7 @@ func (d *Driver) Get(id string) (string, error) {
 	if err := d.mount(id, mp); err != nil {
 		return "", err
 	}
-	return mp, nil
+	return path.Join(mp, "rootfs"), nil
 }
 
 func (d *Driver) Size(id string) (int64, error) {


### PR DESCRIPTION
We place the actual image/containers in the "root" directory, which
allows us to have other data in the toplevel directory in the mount.

For starters, this means the "lost+found" directory from mkfs will
not always be in your container/image.

Secondly, we can create a file "id" in the toplevel dir which is not
visible from the container. This is useful because it allows us to map
back from the device fs to the container if something goes wrong with
the devicemapper metadata.
