### PR TITLE
Implement fallback for getting the size of a container

### DIFF
--- a/archive/changes.go
+++ b/archive/changes.go
@@ -280,6 +280,20 @@ func ChangesDirs(newDir, oldDir string) ([]Change, error) {
 	return newRoot.Changes(oldRoot), nil
 }
 
+func ChangesSize(newDir string, changes []Change) int64 {
+	var size int64
+	for _, change := range changes {
+		if change.Kind == ChangeModify || change.Kind == ChangeAdd {
+			file := filepath.Join(newDir, change.Path)
+			fileInfo, _ := os.Lstat(file)
+			if fileInfo != nil && !fileInfo.IsDir() {
+				size += fileInfo.Size()
+			}
+		}
+	}
+	return size
+}
+
 func ExportChanges(dir string, changes []Change) (Archive, error) {
 	files := make([]string, 0)
 	deletions := make([]string, 0)

--- a/graphdriver/aufs/aufs.go
+++ b/graphdriver/aufs/aufs.go
@@ -219,7 +219,7 @@ func (a *AufsDriver) ApplyDiff(id string, diff archive.Archive) error {
 }
 
 // Returns the size of the contents for the id
-func (a *AufsDriver) Size(id string) (int64, error) {
+func (a *AufsDriver) DiffSize(id string) (int64, error) {
 	return utils.TreeSize(path.Join(a.rootPath(), "diff", id))
 }
 

--- a/graphdriver/devmapper/driver.go
+++ b/graphdriver/devmapper/driver.go
@@ -72,10 +72,6 @@ func (d *Driver) Get(id string) (string, error) {
 	return mp, nil
 }
 
-func (d *Driver) Size(id string) (int64, error) {
-	return -1, fmt.Errorf("Not implemented")
-}
-
 func (d *Driver) mount(id, mountPoint string) error {
 	// Create the target directories if they don't exist
 	if err := os.MkdirAll(mountPoint, 0755); err != nil && !os.IsExist(err) {

--- a/graphdriver/driver.go
+++ b/graphdriver/driver.go
@@ -17,7 +17,6 @@ type Driver interface {
 	Remove(id string) error
 
 	Get(id string) (dir string, err error)
-	Size(id string) (bytes int64, err error)
 
 	Status() [][2]string
 
@@ -28,6 +27,7 @@ type Differ interface {
 	Diff(id string) (archive.Archive, error)
 	Changes(id string) ([]archive.Change, error)
 	ApplyDiff(id string, diff archive.Archive) error
+	DiffSize(id string) (bytes int64, err error)
 }
 
 var (

--- a/graphdriver/dummy/driver.go
+++ b/graphdriver/dummy/driver.go
@@ -76,7 +76,3 @@ func (d *Driver) Get(id string) (string, error) {
 	}
 	return dir, nil
 }
-
-func (d *Driver) Size(id string) (int64, error) {
-	return -1, fmt.Errorf("Not implemented")
-}


### PR DESCRIPTION
This moves Driver.Size() to Differ.DiffSize(), removing the empty
implementations in devmapper and dummy, and renaming the one in aufs.

Then we fall back to a container.Changes() implementation in the non-aufs
case.
