### PR TITLE
Remove 42-layer limit for aufs backend

### DIFF
--- a/archive/diff.go
+++ b/archive/diff.go
@@ -1,6 +1,8 @@
 package archive
 
 import (
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -88,6 +90,199 @@ func ApplyLayer(dest string, layer Archive) error {
 
 		if err := os.Chtimes(k, aTime, mTime); err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+type TimeUpdate struct {
+	path string
+	time []syscall.Timeval
+	mode uint32
+}
+
+// Applies an uncompressed diff layer to a target directory
+func ApplyDirLayer(layer, target string, hardLink bool) error {
+	var updateTimes []TimeUpdate
+	oldmask := syscall.Umask(0)
+	defer syscall.Umask(oldmask)
+	err := filepath.Walk(layer, func(srcPath string, f os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip root
+		if srcPath == layer {
+			return nil
+		}
+
+		var srcStat syscall.Stat_t
+		err = syscall.Lstat(srcPath, &srcStat)
+		if err != nil {
+			return err
+		}
+
+		relPath, err := filepath.Rel(layer, srcPath)
+		if err != nil {
+			return err
+		}
+
+		targetPath := filepath.Join(target, relPath)
+
+		// Skip AUFS metadata
+		if matched, err := filepath.Match(".wh..wh.*", relPath); err != nil || matched {
+			if err != nil || !f.IsDir() {
+				return err
+			}
+			return filepath.SkipDir
+		}
+
+		// Find out what kind of modification happened
+		file := filepath.Base(srcPath)
+
+		// If there is a whiteout, then the file was removed
+		if strings.HasPrefix(file, ".wh.") {
+			originalFile := file[len(".wh."):]
+			deletePath := filepath.Join(filepath.Dir(targetPath), originalFile)
+
+			err = os.RemoveAll(deletePath)
+			if err != nil {
+				return err
+			}
+		} else {
+			var targetStat = &syscall.Stat_t{}
+			err := syscall.Lstat(targetPath, targetStat)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					return err
+				}
+				targetStat = nil
+			}
+
+			if targetStat != nil && !(targetStat.Mode&syscall.S_IFDIR == syscall.S_IFDIR && srcStat.Mode&syscall.S_IFDIR == syscall.S_IFDIR) {
+				// Unless both src and dest are directories we remove the target and recreate it
+				// This is a bit wasteful in the case of only a mode change, but that is unlikely
+				// to matter much
+				err = os.RemoveAll(targetPath)
+				if err != nil {
+					return err
+				}
+				targetStat = nil
+			}
+
+			if f.IsDir() {
+				// Source is a directory
+				if targetStat == nil {
+					err = syscall.Mkdir(targetPath, srcStat.Mode&07777)
+					if err != nil {
+						return err
+					}
+				}
+			} else if srcStat.Mode&syscall.S_IFLNK == syscall.S_IFLNK {
+				// Source is symlink
+				link, err := os.Readlink(srcPath)
+				if err != nil {
+					return err
+				}
+
+				err = os.Symlink(link, targetPath)
+				if err != nil {
+					return err
+				}
+			} else if srcStat.Mode&syscall.S_IFBLK == syscall.S_IFBLK ||
+				srcStat.Mode&syscall.S_IFCHR == syscall.S_IFCHR ||
+				srcStat.Mode&syscall.S_IFIFO == syscall.S_IFIFO ||
+				srcStat.Mode&syscall.S_IFSOCK == syscall.S_IFSOCK {
+				// Source is special file
+				err = syscall.Mknod(targetPath, srcStat.Mode, int(srcStat.Rdev))
+				if err != nil {
+					return err
+				}
+			} else if srcStat.Mode&syscall.S_IFREG == syscall.S_IFREG {
+				// Source is regular file
+				if hardLink {
+					if err := os.Link(srcPath, targetPath); err != nil {
+						return err
+					}
+				} else {
+					fd, err := syscall.Open(targetPath, syscall.O_CREAT|syscall.O_WRONLY, srcStat.Mode&07777)
+					if err != nil {
+						return err
+					}
+					dstFile := os.NewFile(uintptr(fd), targetPath)
+					srcFile, err := os.Open(srcPath)
+					if err != nil {
+						_ = dstFile.Close()
+						return err
+					}
+					_, err = io.Copy(dstFile, srcFile)
+					_ = dstFile.Close()
+					_ = srcFile.Close()
+					if err != nil {
+						return err
+					}
+				}
+			} else {
+				return fmt.Errorf("Unknown type for file %s", srcPath)
+			}
+
+			err = syscall.Lchown(targetPath, int(srcStat.Uid), int(srcStat.Gid))
+			if err != nil {
+				return err
+			}
+
+			if srcStat.Mode&syscall.S_IFLNK != syscall.S_IFLNK {
+				err = syscall.Chmod(targetPath, srcStat.Mode&07777)
+				if err != nil {
+					return err
+				}
+			}
+
+			ts := []syscall.Timeval{
+				syscall.NsecToTimeval(srcStat.Atim.Nano()),
+				syscall.NsecToTimeval(srcStat.Mtim.Nano()),
+			}
+
+			u := TimeUpdate{
+				path: targetPath,
+				time: ts,
+				mode: srcStat.Mode,
+			}
+
+			// Delay time updates until all other changes done, or it is
+			// overwritten for directories (by child changes)
+			updateTimes = append(updateTimes, u)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// We do this in reverse order so that children are updated before parents
+	for i := len(updateTimes) - 1; i >= 0; i-- {
+		update := updateTimes[i]
+
+		O_PATH := 010000000 // Not in syscall yet
+		var err error
+		if update.mode&syscall.S_IFLNK == syscall.S_IFLNK {
+			// Update time on the symlink via O_PATH + futimes(), if supported by the kernel
+
+			fd, err := syscall.Open(update.path, syscall.O_RDWR|O_PATH|syscall.O_NOFOLLOW, 0600)
+			if err == syscall.EISDIR || err == syscall.ELOOP {
+				// O_PATH not supported by kernel, nothing to do, ignore
+			} else if err != nil {
+				return err
+			} else {
+				syscall.Futimes(fd, update.time)
+				syscall.Close(fd)
+			}
+		} else {
+			err = syscall.Utimes(update.path, update.time)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/graph.go
+++ b/graph.go
@@ -154,7 +154,7 @@ func (graph *Graph) Register(jsonData []byte, layerData archive.Archive, img *Im
 	}
 
 	// Create root filesystem in the driver
-	if err := graph.driver.Create(img.ID, img.Parent); err != nil {
+	if err := graph.driver.Create(img.ID, img.Parent, true); err != nil {
 		return fmt.Errorf("Driver %s failed to create image rootfs %s: %s", graph.driver, img.ID, err)
 	}
 	// Mount the root filesystem so we can apply the diff/layer

--- a/graphdriver/aufs/dirs.go
+++ b/graphdriver/aufs/dirs.go
@@ -44,3 +44,14 @@ func getParentIds(root, id string) ([]string, error) {
 	}
 	return out, s.Err()
 }
+
+func getLastLayerIds(root string, parents []string) []string {
+	for i := 0; i < len(parents); i++ {
+		// If this layer had a rootfs, we only return the layers starting here
+		rootfs := path.Join(root, "rootfs", parents[i])
+		if _, err := os.Lstat(rootfs); err == nil {
+			return parents[0 : i+1]
+		}
+	}
+	return parents
+}

--- a/graphdriver/aufs/migrate.go
+++ b/graphdriver/aufs/migrate.go
@@ -77,7 +77,7 @@ func (a *Driver) migrateContainers(pth string, setupInit func(p string) error) e
 				}
 
 				initID := fmt.Sprintf("%s-init", id)
-				if err := a.Create(initID, metadata.Image); err != nil {
+				if err := a.Create(initID, metadata.Image, true); err != nil {
 					return err
 				}
 
@@ -90,7 +90,7 @@ func (a *Driver) migrateContainers(pth string, setupInit func(p string) error) e
 					return err
 				}
 
-				if err := a.Create(id, initID); err != nil {
+				if err := a.Create(id, initID, false); err != nil {
 					return err
 				}
 			}
@@ -144,7 +144,7 @@ func (a *Driver) migrateImage(m *metadata, pth string, migrated map[string]bool)
 			return err
 		}
 		if !a.Exists(m.ID) {
-			if err := a.Create(m.ID, m.ParentID); err != nil {
+			if err := a.Create(m.ID, m.ParentID, true); err != nil {
 				return err
 			}
 		}

--- a/graphdriver/devmapper/driver.go
+++ b/graphdriver/devmapper/driver.go
@@ -56,7 +56,7 @@ func (d *Driver) Cleanup() error {
 	return d.DeviceSet.Shutdown()
 }
 
-func (d *Driver) Create(id, parent string) error {
+func (d *Driver) Create(id, parent string, isImage bool) error {
 	if err := d.DeviceSet.AddDevice(id, parent); err != nil {
 		return err
 	}

--- a/graphdriver/driver.go
+++ b/graphdriver/driver.go
@@ -1,6 +1,7 @@
 package graphdriver
 
 import (
+	"errors"
 	"fmt"
 	"github.com/dotcloud/docker/archive"
 	"github.com/dotcloud/docker/utils"
@@ -9,6 +10,8 @@ import (
 )
 
 var DefaultDriver string
+
+var ErrDriverNotImplemented = errors.New("driver operation not implemented")
 
 type InitFunc func(root string) (Driver, error)
 

--- a/graphdriver/driver.go
+++ b/graphdriver/driver.go
@@ -18,7 +18,10 @@ type InitFunc func(root string) (Driver, error)
 type Driver interface {
 	String() string
 
-	Create(id, parent string) error
+	// isImage == true means we will not do any writes to files
+	// (only replace them, when constructing images), this means
+	// its safe to use hardlinks for file sharing with the parent
+	Create(id, parent string, isImage bool) error
 	Remove(id string) error
 
 	Get(id string) (dir string, err error)

--- a/graphdriver/dummy/driver.go
+++ b/graphdriver/dummy/driver.go
@@ -43,7 +43,7 @@ func copyDir(src, dst string) error {
 	return nil
 }
 
-func (d *Driver) Create(id string, parent string) error {
+func (d *Driver) Create(id string, parent string, isImage bool) error {
 	dir := d.dir(id)
 	if err := os.MkdirAll(path.Dir(dir), 0700); err != nil {
 		return err

--- a/image.go
+++ b/image.go
@@ -249,25 +249,6 @@ func (img *Image) getParentsSize(size int64) int64 {
 	return parentImage.getParentsSize(size)
 }
 
-// Depth returns the number of parents for a
-// current image
-func (img *Image) Depth() (int, error) {
-	var (
-		count  = 0
-		parent = img
-		err    error
-	)
-
-	for parent != nil {
-		count++
-		parent, err = parent.GetParent()
-		if err != nil {
-			return -1, err
-		}
-	}
-	return count, nil
-}
-
 // Build an Image object from raw json data
 func NewImgJSON(src []byte) (*Image, error) {
 	ret := &Image{}

--- a/runtime.go
+++ b/runtime.go
@@ -749,7 +749,9 @@ func (runtime *Runtime) Unmount(container *Container) error {
 
 func (runtime *Runtime) Changes(container *Container) ([]archive.Change, error) {
 	if differ, ok := runtime.driver.(graphdriver.Differ); ok {
-		return differ.Changes(container.ID)
+		if changes, err := differ.Changes(container.ID); err != graphdriver.ErrDriverNotImplemented {
+			return changes, err
+		}
 	}
 	cDir, err := runtime.driver.Get(container.ID)
 	if err != nil {
@@ -764,7 +766,9 @@ func (runtime *Runtime) Changes(container *Container) ([]archive.Change, error) 
 
 func (runtime *Runtime) Diff(container *Container) (archive.Archive, error) {
 	if differ, ok := runtime.driver.(graphdriver.Differ); ok {
-		return differ.Diff(container.ID)
+		if diff, err := differ.Diff(container.ID); err != graphdriver.ErrDriverNotImplemented {
+			return diff, err
+		}
 	}
 
 	changes, err := runtime.Changes(container)

--- a/runtime.go
+++ b/runtime.go
@@ -24,9 +24,6 @@ import (
 	"time"
 )
 
-// Set the max depth to the aufs restriction
-const MaxImageDepth = 42
-
 var defaultDns = []string{"8.8.8.8", "8.8.4.4"}
 
 type Capabilities struct {
@@ -361,17 +358,6 @@ func (runtime *Runtime) Create(config *Config, name string) (*Container, []strin
 	img, err := runtime.repositories.LookupImage(config.Image)
 	if err != nil {
 		return nil, nil, err
-	}
-
-	// We add 2 layers to the depth because the container's rw and
-	// init layer add to the restriction
-	depth, err := img.Depth()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if depth+2 >= MaxImageDepth {
-		return nil, nil, fmt.Errorf("Cannot create container with more than %d parents", MaxImageDepth)
 	}
 
 	checkDeprecatedExpose := func(config *Config) bool {

--- a/runtime.go
+++ b/runtime.go
@@ -457,7 +457,7 @@ func (runtime *Runtime) Create(config *Config, name string) (*Container, []strin
 	}
 
 	initID := fmt.Sprintf("%s-init", container.ID)
-	if err := runtime.driver.Create(initID, img.ID); err != nil {
+	if err := runtime.driver.Create(initID, img.ID, false); err != nil {
 		return nil, nil, err
 	}
 	initPath, err := runtime.driver.Get(initID)
@@ -468,7 +468,7 @@ func (runtime *Runtime) Create(config *Config, name string) (*Container, []strin
 		return nil, nil, err
 	}
 
-	if err := runtime.driver.Create(container.ID, initID); err != nil {
+	if err := runtime.driver.Create(container.ID, initID, false); err != nil {
 		return nil, nil, err
 	}
 	resolvConf, err := utils.GetResolvConf()


### PR DESCRIPTION
We modify the aufs layout such that each image can have
either a "diff" directory containing an AUFS style layer, or a
"rootfs" directory, containing a full filesystem image.

driver.Create() is modified so that it knows if the created layer is
an image or not, and whenever we're creating an image that would
be 41 layers (which will not work for containers due to 2 extra layers
for init and rw) we instead create a completely new rootfs directory.

Whenever we mount an image/container we only go up to (and including)
the nearest rootfs, which means that no matter how deep the hierarchies
are we never get more than 42 aufs layers.

When we manally apply layers we use ApplyLayerDir and tell it to
hardlink regular files, which means that most of the diskspace for
layers are shared even if there are more than 42 layers. This is safe
because we never do in-place modification of files in images during
applyLayer so no changes will reach the lower layers due to the
hardlinks.

All the Differ methods in the aufs driver return ErrDriverNotImplemented
if the layer has a rootfs, which means we fall back to the standard
implementation of these.
