### PR TITLE
Add beam unix tests and fixes

### DIFF
--- a/pkg/beam/service.go
+++ b/pkg/beam/service.go
@@ -16,8 +16,8 @@ import (
 // Note that if the underlying file descriptor received in attachment is nil or does
 // not point to a connection, that message will be skipped.
 //
-func Listen(conn *net.UnixConn, name string) (net.Listener, error) {
-	endpoint, err := SendPipe(conn, []byte(name))
+func Listen(conn *BeamConn, name string) (net.Listener, error) {
+	endpoint, err := conn.SendBeam([]byte(name))
 	if err != nil {
 		return nil, err
 	}
@@ -27,7 +27,7 @@ func Listen(conn *net.UnixConn, name string) (net.Listener, error) {
 	}, nil
 }
 
-func Connect(ctx *net.UnixConn, name string) (net.Conn, error) {
+func Connect(ctx *BeamConn, name string) (net.Conn, error) {
 	l, err := Listen(ctx, name)
 	if err != nil {
 		return nil, err
@@ -41,12 +41,12 @@ func Connect(ctx *net.UnixConn, name string) (net.Conn, error) {
 
 type listener struct {
 	name     string
-	endpoint *net.UnixConn
+	endpoint *BeamConn
 }
 
 func (l *listener) Accept() (net.Conn, error) {
 	for {
-		_, f, err := Receive(l.endpoint)
+		_, f, err := l.endpoint.Receive()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/beam/unix.go
+++ b/pkg/beam/unix.go
@@ -1,19 +1,39 @@
 package beam
 
 import (
+	"bufio"
+	"container/list"
 	"fmt"
 	"net"
 	"os"
 	"syscall"
-	"bufio"
 )
+
+type BeamConn struct {
+	*net.UnixConn
+	fds list.List
+}
+
+func NewFromUnix(conn *net.UnixConn) *BeamConn {
+	return &BeamConn{UnixConn: conn}
+}
+
+// Framing:
+
+// In order to handle framing in Send/Recieve, as these give frame
+// boundaries we use a very simple 4 bytes header. It is a big endiand
+// uint32 where the high bit is set if the message includes a file
+// descriptor. The rest of the uint32 is the length of the next frame.
+// We need the bit in order to be able to assign recieved fds to
+// the right message, as multiple messages may be coalesced into
+// a single recieve operation.
 
 func debugCheckpoint(msg string, args ...interface{}) {
 	if os.Getenv("DEBUG") == "" {
 		return
 	}
 	os.Stdout.Sync()
-	tty,_ := os.OpenFile("/dev/tty", os.O_RDWR, 0700)
+	tty, _ := os.OpenFile("/dev/tty", os.O_RDWR, 0700)
 	fmt.Fprintf(tty, msg, args...)
 	bufio.NewScanner(tty).Scan()
 	tty.Close()
@@ -22,7 +42,7 @@ func debugCheckpoint(msg string, args ...interface{}) {
 // Send sends a new message on conn with data and f as payload and
 // attachment, respectively.
 // On success, f is closed
-func Send(conn *net.UnixConn, data []byte, f *os.File) error {
+func (conn *BeamConn) Send(data []byte, f *os.File) error {
 	{
 		var fd int = -1
 		if f != nil {
@@ -34,7 +54,7 @@ func Send(conn *net.UnixConn, data []byte, f *os.File) error {
 	if f != nil {
 		fds = append(fds, int(f.Fd()))
 	}
-	if err := sendUnix(conn, data, fds...); err != nil {
+	if err := conn.sendUnix(data, fds...); err != nil {
 		return err
 	}
 
@@ -50,7 +70,7 @@ func Send(conn *net.UnixConn, data []byte, f *os.File) error {
 // If more than 1 file descriptor is sent in the message, they are all
 // closed except for the first, which is the attachment.
 // It is legal for a message to have no attachment or an empty payload.
-func Receive(conn *net.UnixConn) (rdata []byte, rf *os.File, rerr error) {
+func (conn *BeamConn) Receive() (rdata []byte, rf *os.File, rerr error) {
 	defer func() {
 		var fd int = -1
 		if rf != nil {
@@ -58,19 +78,42 @@ func Receive(conn *net.UnixConn) (rdata []byte, rf *os.File, rerr error) {
 		}
 		debugCheckpoint("===DEBUG=== Receive() -> '%s'[%d]. Hit enter to continue.\n", rdata, fd)
 	}()
-	for {
-		data, fds, err := receiveUnix(conn, 1)
+
+	// Read header
+	header := make([]byte, 4)
+	nRead := uint32(0)
+
+	for nRead < 4 {
+		n, err := conn.receiveUnix(header[nRead:])
 		if err != nil {
 			return nil, nil, err
 		}
-		var f *os.File
-		if len(fds) >= 1 {
-			f = os.NewFile(uintptr(fds[0]), "")
-		}
-		return data, f, nil
+		nRead = nRead + uint32(n)
 	}
-	panic("impossibru")
-	return nil, nil, nil
+
+	length, hasFd := parseHeader(header)
+
+	if hasFd {
+		front := conn.fds.Front()
+		if front == nil {
+			return nil, nil, fmt.Errorf("No expected file descriptor in message")
+		}
+
+		rf = front.Value.(*os.File)
+	}
+
+	rdata = make([]byte, length)
+
+	nRead = 0
+	for nRead < length {
+		n, err := conn.receiveUnix(rdata[nRead:])
+		if err != nil {
+			return nil, nil, err
+		}
+		nRead = nRead + uint32(n)
+	}
+
+	return
 }
 
 // SendPipe creates a new unix socket pair, sends one end as the attachment
@@ -107,7 +150,7 @@ func Receive(conn *net.UnixConn) (rdata []byte, rf *os.File, rerr error) {
 // allows for arbitrarily complex service discovery and retry logic to take place,
 // without complicating application code.
 //
-func SendPipe(conn *net.UnixConn, data []byte) (endpoint *net.UnixConn, err error) {
+func (conn *BeamConn) SendPipe(data []byte) (endpoint *net.UnixConn, err error) {
 	debugCheckpoint("===DEBUG=== SendPipe('%s'). Hit enter to confirm: ", data)
 	local, remote, err := SocketPair()
 	if err != nil {
@@ -123,26 +166,105 @@ func SendPipe(conn *net.UnixConn, data []byte) (endpoint *net.UnixConn, err erro
 	if err != nil {
 		return nil, err
 	}
-	local.Close()
-	if err := Send(conn, data, remote); err != nil {
+	if err := conn.Send(data, remote); err != nil {
 		return nil, err
 	}
 	return endpoint, nil
 }
 
-func receiveUnix(conn *net.UnixConn, maxFds int) ([]byte, []int, error) {
-	buf := make([]byte, 4096)
-	oob := make([]byte, syscall.CmsgSpace(maxFds*4))
-	bufn, oobn, _, _, err := conn.ReadMsgUnix(buf, oob)
+func (conn *BeamConn) SendBeam(data []byte) (*BeamConn, error) {
+	endpoint, err := conn.SendPipe(data)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return buf[:bufn], extractFds(oob[:oobn], maxFds), nil
+	return NewFromUnix(endpoint), nil
 }
 
-func sendUnix(conn *net.UnixConn, data []byte, fds ...int) error {
-	_, _, err := conn.WriteMsgUnix(data, syscall.UnixRights(fds...), nil)
-	return err
+func (conn *BeamConn) receiveUnix(buf []byte) (int, error) {
+	oob := make([]byte, syscall.CmsgSpace(4))
+	bufn, oobn, _, _, err := conn.ReadMsgUnix(buf, oob)
+	if err != nil {
+		return 0, err
+	}
+	fds := extractFds(oob[:oobn], 1)
+	if len(fds) >= 1 {
+		f := os.NewFile(uintptr(fds[0]), "")
+		conn.fds.PushBack(f)
+	}
+
+	return bufn, nil
+}
+
+func makeHeader(data []byte, fds []int) ([]byte, error) {
+	header := make([]byte, 4)
+
+	length := uint32(len(data))
+
+	if length > 0x7fffffff {
+		return nil, fmt.Errorf("Data to large")
+	}
+
+	if len(fds) != 0 {
+		length = length | 0x80000000
+	}
+	header[0] = byte((length >> 24) & 0xff)
+	header[1] = byte((length >> 16) & 0xff)
+	header[2] = byte((length >> 8) & 0xff)
+	header[3] = byte((length >> 0) & 0xff)
+
+	return header, nil
+}
+
+func parseHeader(header []byte) (uint32, bool) {
+	length := uint32(header[0])<<24 | uint32(header[1])<<16 | uint32(header[2])<<8 | uint32(header[3])
+	hasFd := length&0x80000000 != 0
+	length = length & ^uint32(0x80000000)
+
+	return length, hasFd
+}
+
+func (conn *BeamConn) sendUnix(data []byte, fds ...int) error {
+	header, err := makeHeader(data, fds)
+	if err != nil {
+		return err
+	}
+
+	// There is a bug in conn.WriteMsgUnix where it doesn't correctly return
+	// the number of bytes writte (http://code.google.com/p/go/issues/detail?id=7645)
+	// So, we can't rely on the return value from it. However, we must use it to
+	// send the fds. In order to handle this we only write one byte using WriteMsgUnix
+	// (when we have to), as that can only ever block or fully suceed. We then write
+	// the rest with conn.Write()
+	// The reader side should not rely on this though, as hopefully this gets fixed
+	// in go later.
+	written := 0
+	if len(fds) != 0 {
+		oob := syscall.UnixRights(fds...)
+		wrote, _, err := conn.WriteMsgUnix(header[0:1], oob, nil)
+		if err != nil {
+			return err
+		}
+		written = written + wrote
+	}
+
+	for written < len(header) {
+		wrote, err := conn.Write(header[written:])
+		if err != nil {
+			return err
+		}
+		written = written + wrote
+	}
+
+	written = 0
+	for written < len(data) {
+		wrote, err := conn.Write(data[written:])
+		if err != nil {
+			return err
+		}
+		written = written + wrote
+	}
+
+	return nil
 }
 
 func extractFds(oob []byte, maxFds int) (fds []int) {
@@ -207,7 +329,7 @@ func SocketPair() (a *os.File, b *os.File, err error) {
 
 func USocketPair() (*net.UnixConn, *net.UnixConn, error) {
 	debugCheckpoint("===DEBUG=== USocketPair(). Hit enter to confirm: ")
-	defer debugCheckpoint ("===DEBUG=== USocketPair() returned. Hit enter to confirm ")
+	defer debugCheckpoint("===DEBUG=== USocketPair() returned. Hit enter to confirm ")
 	a, b, err := SocketPair()
 	if err != nil {
 		return nil, nil, err
@@ -226,6 +348,15 @@ func USocketPair() (*net.UnixConn, *net.UnixConn, error) {
 	}
 
 	return uA, uB, nil
+}
+
+func BeamPair() (*BeamConn, *BeamConn, error) {
+	a, b, err := USocketPair()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return NewFromUnix(a), NewFromUnix(b), nil
 }
 
 // FdConn wraps a file descriptor in a standard *net.UnixConn object, or

--- a/pkg/beam/unix_test.go
+++ b/pkg/beam/unix_test.go
@@ -25,6 +25,30 @@ func TestSocketPair(t *testing.T) {
 	fmt.Printf("still open: %v\n", a.Fd())
 }
 
+func TestUSocketPair(t *testing.T) {
+	a, b, err := USocketPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	data := "hello world!"
+	go func() {
+		a.Write([]byte(data))
+		a.Close()
+	}()
+	res := make([]byte, 1024)
+	size, err := b.Read(res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if size != len(data) {
+		t.Fatal("Unexpected size")
+	}
+	if string(res[0:size]) != data {
+		t.Fatal("Unexpected data")
+	}
+}
+
 func TestSendUnixSocket(t *testing.T) {
 	a1, a2, err := USocketPair()
 	if err != nil {
@@ -83,4 +107,131 @@ func TestSendUnixSocket(t *testing.T) {
 		t.Fatal(err)
 	}
 	fmt.Printf("---> %s\n", data)
+
+}
+
+// Ensure we get proper segmenting of messages
+func TestSendSegmenting(t *testing.T) {
+	a, b, err := USocketPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+	defer b.Close()
+
+	extrafd1, extrafd2, err := SocketPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	extrafd2.Close()
+
+	go func() {
+		Send(a, []byte("message 1"), nil)
+		Send(a, []byte("message 2"), extrafd1)
+		Send(a, []byte("message 3"), nil)
+	}()
+
+	msg1, file1, err := Receive(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(msg1) != "message 1" {
+		t.Fatal("unexpected msg1:", string(msg1))
+	}
+	if file1 != nil {
+		t.Fatal("unexpectedly got file1")
+	}
+
+	msg2, file2, err := Receive(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(msg2) != "message 2" {
+		t.Fatal("unexpected msg2:", string(msg2))
+	}
+	if file2 == nil {
+		t.Fatal("didn't get file2")
+	}
+	file2.Close()
+
+	msg3, file3, err := Receive(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(msg3) != "message 3" {
+		t.Fatal("unexpected msg3:", string(msg3))
+	}
+	if file3 != nil {
+		t.Fatal("unexpectedly got file3")
+	}
+
+}
+
+// Test sending a zero byte message
+func TestSendEmpty(t *testing.T) {
+	a, b, err := USocketPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+	defer b.Close()
+	go func() {
+		Send(a, []byte{}, nil)
+	}()
+
+	msg, file, err := Receive(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(msg) != 0 {
+		t.Fatalf("unexpected non-empty message: %v", msg)
+	}
+	if file != nil {
+		t.Fatal("unexpectedly got file")
+	}
+
+}
+
+func makeLarge(size int) []byte {
+	res := make([]byte, size)
+	for i := range res {
+		res[i] = byte(i % 255)
+	}
+	return res
+}
+
+func verifyLarge(data []byte, size int) bool {
+	if len(data) != size {
+		return false
+	}
+	for i := range data {
+		if data[i] != byte(i%255) {
+			return false
+		}
+	}
+	return true
+}
+
+// Test sending a large message
+func TestSendLarge(t *testing.T) {
+	a, b, err := USocketPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer a.Close()
+	defer b.Close()
+	go func() {
+		Send(a, makeLarge(100000), nil)
+	}()
+
+	msg, file, err := Receive(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !verifyLarge(msg, 100000) {
+		t.Fatalf("unexpected message (size %d)", len(msg))
+	}
+	if file != nil {
+		t.Fatal("unexpectedly got file")
+	}
 }


### PR DESCRIPTION
This adds some tests to unix_test.go showing things that don't work atm,
as well as fixes a bunch of things:
- set CLOEXEC
- don't double free fds
- make fd passing limiting a bit more robust

These are all pretty trivial, i'll continue to look for ways to fix the new test failures.
