### PR TITLE
Just experimenting....

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -27,6 +27,7 @@ import (
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/graph"
 	"github.com/docker/docker/image"
+	"github.com/docker/docker/net"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/broadcastwriter"
 	"github.com/docker/docker/pkg/graphdb"
@@ -100,6 +101,7 @@ type Daemon struct {
 	driver         graphdriver.Driver
 	execDriver     execdriver.Driver
 	trustStore     *trust.TrustStore
+	networking     *net.Networking
 }
 
 // Install installs daemon capabilities to eng.
@@ -586,6 +588,7 @@ func (daemon *Daemon) newContainer(name string, config *runconfig.Config, img *i
 		execCommands:    newExecStore(),
 	}
 	container.root = daemon.containerRoot(container.ID)
+
 	return container, err
 }
 
@@ -830,6 +833,11 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 		return nil, err
 	}
 
+	networking := net.NetworkingThingy
+	//if err != nil {
+	//return nil, err
+	//}
+
 	log.Debugf("Creating repository list")
 	repositories, err := graph.NewTagStore(path.Join(config.Root, "repositories-"+driver.String()), g, config.Mirrors, config.InsecureRegistries)
 	if err != nil {
@@ -916,6 +924,7 @@ func NewDaemonFromDirectory(config *Config, eng *engine.Engine) (*Daemon, error)
 		execDriver:     ed,
 		eng:            eng,
 		trustStore:     t,
+		networking:     networking,
 	}
 	if err := daemon.restore(); err != nil {
 		return nil, err

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker/api"
 	"github.com/docker/docker/api/client"
 	"github.com/docker/docker/dockerversion"
+	_ "github.com/docker/docker/net/something"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/docker/docker/utils"

--- a/extensions/network.go
+++ b/extensions/network.go
@@ -1,0 +1,156 @@
+package extensions
+
+import (
+	"net"
+)
+
+const (
+	CONTAINER_ID = "ContainerId"
+)
+
+// NetworkProvider is a composition of various extensions to provide networking
+// functionality.  When a network is created, a provider can be chosen at that
+// type.
+type NetworkProvider interface {
+	// Opts returns a specification of options recognized by the extension.
+	// The runtime uses this schema to query users for opts when loading extensionss.
+	// Opts are made available to the extensions under the key "/opts" in its State.
+	//
+	// Schema example:
+	// []Opt{
+	//	{"key", "string", "A secret key to encrypt all traffic"},
+	//	{"bridge", "string", "The name of the bridge interface to configure"},
+	//	{"autoaddr", "bool", "Auto-detect a network range if the bridge is not already configured"},
+	// }
+	//Opts() []Opt
+
+	Name() string
+	NetworkExtension() NetworkExtension
+	NamingExtension() NamingExtension
+	PortExtension() PortExtension
+	GetNetwork(idOrName string) (Network, error)
+
+	Init(s State) error
+	Shutdown(s State) error
+}
+
+type NamingExtension interface {
+	AssignNamesInNetwork(network Network, names map[string]*Endpoint) error
+
+	// This is to support links in which the link names are scoped to the container
+	AssignNamesInContainer(containerId string, names map[string]*Endpoint) error
+}
+
+type PortExtension interface {
+	ExposePort(endpoint *Endpoint, network Network, port *Port, hostPort int) error
+	UnexposePort(endpoint *Endpoint, network Network, port *Port, hostPort int) error
+}
+
+// I assume this type exists somewhere else too
+type Port struct {
+	Port     int
+	Protocol string
+}
+
+// NetExtension is the interface implemented by a network extension.
+// Network extensions implement new ways for Docker to interconnect containers
+// over IP networks.
+
+type NetworkExtension interface {
+	ListNetworks() ([]Network, error)
+
+	GetNetwork(id string) (Network, error)
+
+	// Creates a network
+	// The implementation of this method should be idempotent such that if
+	// then network already exists it will succeed
+	CreateNet(net Network) error
+
+	// Removes a network, this should be idempotent such that if the network
+	// does not if exist it should succeed
+	RemoveNet(net Network) error
+}
+
+type NamespaceFactory interface {
+	IsHost() bool
+	IsContainer() bool
+	GetNamespace() string //or whatever type a namespace is
+}
+
+type Network interface {
+	Id() string
+	NamespaceFactory() NamespaceFactory
+	CustomDnsSupported() bool
+	Provider() NetworkProvider
+	ListEndpoints() ([]*Endpoint, error)
+	LookupEndpoint(metaData map[string]string) (*Endpoint, error)
+	// Called on container create
+	CreateEndpoint(endpoint *Endpoint) error
+	// Called on container start
+	ActivateEndpoint(endpoint *Endpoint) error
+	// Called on container stop
+	DeactivateEndpoint(endpoint *Endpoint) error
+	// Called on container remove
+	RemoveEndpoint(endpoint *Endpoint) error
+}
+
+type Endpoint struct {
+	Id         string
+	Interfaces []*Interface
+	MetaData   map[string]string
+}
+
+type Opt struct {
+	Key  string
+	Type string
+	Desc string
+}
+
+// this is a network configuration provided by the extension at network creation
+// time. it is not intended to be malleable by docker itself, but should be
+// populated with all the generic configuration required by dockerinit to work
+// with the container from a network perspective.
+type Interface struct {
+	net.Interface
+	Addresses []string // a list of CIDR addresses to assign to the interface
+	Gateway   net.IP   // the gateway the interface uses
+	Routes    []Route  // routes to set on this interface
+}
+
+type Route struct {
+	Target  string // The CIDR address of the route target
+	Gateway string // The CIDR address of the gateway (empty string means no gateway)
+}
+
+// State is an abstract database provided by the core for a extension to easily store
+// and retrieve its state across its lifecycle.
+//
+// State data is organized like a simplified filesystem: nodes in the tree
+// are referenced by slash-separated paths. A node can be either a directory
+// or a file. Files have no metadata, only data.
+//
+// An important property of State is full support of versioning and transactions.
+// All changes return a globally unique hash of the current state of the database.
+//
+// State supports transactions:
+// [...]
+// var (
+//    s State
+//    err error
+//  )
+// s.Autocommit(false)
+// s, _ = s.("/foo/bar")
+// s, _ = s.Set("/animals/moby dock", "Moby Dock is a whale")
+// _ = s.Commit()
+
+type State interface {
+	List(dir string) ([]string, error)
+	Get(key string) (string, error)
+
+	// FIXME: for now we stick to naive crud,
+	// bring back transactions and versioning once
+	// we have a working poc.
+	Set(key, val string) error
+	Remove(key string) error
+	Mkdir(dir string) error
+}

--- a/net/net.go
+++ b/net/net.go
@@ -1,0 +1,156 @@
+package net
+
+import (
+	"errors"
+	e "github.com/docker/docker/engine"
+	"github.com/docker/docker/extensions"
+)
+
+var NetworkingThingy *Networking
+
+type Networking struct {
+	Providers []extensions.NetworkProvider
+	state     extensions.State
+}
+
+//func NewNetworking() (*Networking, error) {
+//return &Networking{
+//}, nil
+//}
+
+func (n *Networking) CreateContainerEndpoint(networkName string, containerId string) (extensions.Network, *extensions.Endpoint, error) {
+	network, err := n.GetNetwork(networkName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if network == nil {
+		return nil, nil, errors.New("Failed to find network " + networkName)
+	}
+
+	endpoint := &extensions.Endpoint{
+		MetaData: map[string]string{
+			extensions.CONTAINER_ID: containerId,
+		},
+	}
+
+	err = network.CreateEndpoint(endpoint)
+
+	return network, endpoint, err
+}
+
+func containerMetaData(containerId string) map[string]string {
+	return map[string]string{
+		extensions.CONTAINER_ID: containerId,
+	}
+}
+
+func (n *Networking) RemoveContainerEndpoint(networkName string, containerId string) error {
+	network, err := n.GetNetwork(networkName)
+	if err != nil {
+		return err
+	}
+
+	if network == nil {
+		return nil
+	}
+
+	endpoint, err := network.LookupEndpoint(containerMetaData(containerId))
+	if err != nil {
+		return err
+	}
+
+	if endpoint == nil {
+		return nil
+	}
+
+	return network.RemoveEndpoint(endpoint)
+}
+
+func (n *Networking) GetNetwork(name string) (network extensions.Network, err error) {
+	for _, provider := range n.Providers {
+		network, err := provider.NetworkExtension().GetNetwork(name)
+
+		// Ignore errors if we can find the right network somewhere else
+		if err != nil {
+			continue
+		}
+
+		if network != nil {
+			return network, err
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, errors.New("Failed to find network for " + name)
+}
+
+func (n *Networking) Install(eng *e.Engine) error {
+	eng.Register("net_create", n.CmdCreate)
+	eng.Register("net_rm", n.CmdRm)
+	eng.Register("net_ls", n.CmdLs)
+	eng.Register("net_join", n.CmdJoin)
+	eng.Register("net_leave", n.CmdLeave)
+	eng.Register("net_import", n.CmdImport)
+	eng.Register("net_export", n.CmdExport)
+	return nil
+}
+
+func (n *Networking) CmdCreate(j *e.Job) e.Status {
+	if len(j.Args) != 1 {
+		return j.Errorf("usage: %s NAME", j.Name)
+	}
+	// FIXME
+	return e.StatusOK
+}
+
+func (n *Networking) CmdLs(j *e.Job) e.Status {
+	if len(j.Args) != 1 {
+		return j.Errorf("usage: %s NAME", j.Name)
+	}
+	// FIXME
+	return e.StatusOK
+}
+
+func (n *Networking) CmdRm(j *e.Job) e.Status {
+	if len(j.Args) != 1 {
+		return j.Errorf("usage: %s NAME", j.Name)
+	}
+	// FIXME
+	return e.StatusOK
+}
+
+func (n *Networking) CmdJoin(j *e.Job) e.Status {
+	if len(j.Args) != 1 {
+		return j.Errorf("usage: %s NAME", j.Name)
+	}
+	// FIXME
+	return e.StatusOK
+}
+
+func (n *Networking) CmdLeave(j *e.Job) e.Status {
+	if len(j.Args) != 1 {
+		return j.Errorf("usage: %s NAME", j.Name)
+	}
+	// FIXME
+	return e.StatusOK
+}
+
+func (n *Networking) CmdImport(j *e.Job) e.Status {
+	if len(j.Args) != 1 {
+		return j.Errorf("usage: %s NAME", j.Name)
+	}
+	// FIXME
+	return e.StatusOK
+}
+
+func (n *Networking) CmdExport(j *e.Job) e.Status {
+	if len(j.Args) != 1 {
+		return j.Errorf("usage: %s NAME", j.Name)
+	}
+	// FIXME
+	return e.StatusOK
+}

--- a/net/something/base_provider.go
+++ b/net/something/base_provider.go
@@ -1,0 +1,34 @@
+package something
+
+import (
+	"github.com/docker/docker/extensions"
+)
+
+type BaseProvider struct {
+	name             string
+	namespaceFactory extensions.NamespaceFactory
+	namingExtension  extensions.NamingExtension
+	networkExtension extensions.NetworkExtension
+	portExtension    extensions.PortExtension
+	State            extensions.State
+}
+
+func (b *BaseProvider) Name() string {
+	return b.name
+}
+
+func (b *BaseProvider) NamingExtension() extensions.NamingExtension {
+	return b.namingExtension
+}
+
+func (b *BaseProvider) NamespaceFactory() extensions.NamespaceFactory {
+	return b.namespaceFactory
+}
+
+func (b *BaseProvider) PortExtension() extensions.PortExtension {
+	return b.portExtension
+}
+
+func (b *BaseProvider) NetworkExtension() extensions.NetworkExtension {
+	return b.networkExtension
+}

--- a/net/something/default_provider.go
+++ b/net/something/default_provider.go
@@ -1,0 +1,88 @@
+package something
+
+import (
+	"github.com/docker/docker/extensions"
+	"strings"
+)
+
+type BuiltinProvider struct {
+	BaseProvider
+	hostMode      *BuiltInNetworkMode
+	containerMode *BuiltInNetworkMode
+}
+
+func (d *BuiltinProvider) Init(s extensions.State) error {
+	d.State = s
+	d.hostMode = &BuiltInNetworkMode{
+		hostMode: true,
+		id:       "host",
+	}
+	d.containerMode = &BuiltInNetworkMode{
+		hostMode: false,
+		id:       "container",
+	}
+	return nil
+}
+
+func (d *BuiltinProvider) Shutdown(s extensions.State) error {
+	return nil
+}
+
+func (d *BuiltinProvider) GetNetwork(idOrName string) (extensions.Network, error) {
+	if idOrName == "host" {
+		return d.hostMode, nil
+	} else if strings.HasPrefix("container:", idOrName) {
+		return d.containerMode, nil
+	}
+
+	return nil, nil
+}
+
+type BuiltInNetworkMode struct {
+	id               string
+	hostMode         bool
+	defaultProvider  *BuiltinProvider
+	namespaceFactory extensions.NamespaceFactory
+}
+
+func (d *BuiltInNetworkMode) Id() string {
+	return d.id
+}
+
+func (d *BuiltInNetworkMode) CustomDnsSupported() bool {
+	return d.hostMode
+}
+
+func (d *BuiltInNetworkMode) NamespaceFactory() extensions.NamespaceFactory {
+	return d.namespaceFactory
+}
+
+func (d *BuiltInNetworkMode) Provider() extensions.NetworkProvider {
+	return d.defaultProvider
+}
+
+func (d *BuiltInNetworkMode) ListEndpoints() ([]*extensions.Endpoint, error) {
+	// TODO: need to pull from state
+	return []*extensions.Endpoint{}, nil
+}
+
+func (d *BuiltInNetworkMode) LookupEndpoint(metaData map[string]string) (*extensions.Endpoint, error) {
+	// TODO
+	return nil, nil
+}
+
+func (d *BuiltInNetworkMode) CreateEndpoint(endpoint *extensions.Endpoint) error {
+	return nil
+}
+
+func (d *BuiltInNetworkMode) ActivateEndpoint(endpoint *extensions.Endpoint) error {
+	return nil
+}
+
+func (d *BuiltInNetworkMode) DeactivateEndpoint(endpoint *extensions.Endpoint) error {
+	return nil
+}
+
+func (d *BuiltInNetworkMode) RemoveEndpoint(endpoint *extensions.Endpoint) error {
+	return nil
+}


### PR DESCRIPTION
I couldn't help but code something...  I've been experimenting with different incarnations of the extension interfaces.  I created this pull request just so you could see what I'm up to.  The main diff is https://github.com/ibuildthecloud/docker/commit/146ddf90d8de8107f22db41354d7d32e8563e9e5  Obviously don't merge this.  I realize much of this will be throw away.  Here's some of the ideas I've been playing with
## Network Provider

I've created the concept of a Network Provider.  So far there are three extension interfaces we've talked about: Ports, Network, and DNS/Naming.  These extensions are loosely related.  A Network Provider provides a means to compose these extensions into one working set.  Every Port extension will not work with every Network extension for example.  It is far too difficult to ensure such a thing.  But many Port extensions will be compatible with many other Network extensions.  The Network Provider allows you to group specific extensions together into a validated set.

Additionally, the network provider can be used to assist in creating a network.  When you create a network you could say `docker network create --provider=xyz`.  This allows the user to say that they want a network implemented by system X, but not necessarily have to say "vlan."
## Remove Required Core State

Most of the code I've seen so far has some global map of all Networks and Endpoints.  This basically implies we will have one core state in Docker that has all network information in it.  This approach can either be a great help or a hindrance depending on your networking system.

For many drivers it will be very convenient to have the State object that is magically synced across the cluster.  From some SDN systems, the SDN system already has a global view of all hosts, networks, and containers.  Requiring the core state be in Docker means that the SDN will need to always synchronize state between the two.

What I've done in this PR is move the management of the state to the Network Provider.  When the Network Provider is initialized it is passed a State object which it is free to use at it will.  Core docker does not maintain a list of networks/endpoints but instead iterates over the Providers and calls ListNetworks() or GetNetwork(id).  This small change makes it such that there is no required one core state in Docker.  State can be distributed across providers in provider specific fashions such that three providers installed can synchronize state in three different ways if they're so inclined.
## More Endpoint LifeCycle methods

Add and remove endpoint is not really sufficient.  There needs to be add, remove, activate, deactivate.  This essentially maps to container create, start, stop, remove.  The networking system needs to be aware of all these life cycle events.  On create the networking system should reserve resources.  For example if you are doing L2 virtualization, you'd probably reserve a MAC address at this time.  On start the network system should make connectivity possible.  On stop the network system should attempt to gracefully remove connectivity (a PreDeactivate could be needed too so you can do things like gracefully remove a container from a load balancer).  On remove the networking system should release any resources reserved to the container.
## Find incremental approaches

I wanted to walk through all the changes needed to see if there are ways we can implement this without boiling the ocean.  I believe there are some simple ways we can roll out this functionality without requiring huge refactoring of libcontainer, persistent netns, a distribute state implementation, vxlan, etc.  I can share my thoughts at a later time. 
