### PR TITLE
More core adaptations

### DIFF
--- a/daemon/container.go
+++ b/daemon/container.go
@@ -712,7 +712,7 @@ func (container *Container) Stop(seconds int) error {
 		for _, epid := range endpoints {
 			var err error
 			var net network.Network
-			if net, err = container.daemon.extensions.Networks().GetNetwork(netid); err == nil {
+			if net, err = container.daemon.networks.GetNetwork(netid); err == nil {
 				err = net.Unlink(string(epid))
 			}
 			if err != nil {

--- a/daemon/create.go
+++ b/daemon/create.go
@@ -72,14 +72,14 @@ func (daemon *Daemon) ContainerCreate(job *engine.Job) engine.Status {
 
 func (daemon *Daemon) attachContainerToDefaultNetwork(cid, name string) (network.Endpoint, error) {
 	// Retrieve the default network that the new container should be joining.
-	netid := daemon.extensions.Networks().DefaultNetworkID
-	defaultNet, err := daemon.extensions.Networks().GetNetwork(netid)
+	netid := daemon.networks.DefaultNetworkID
+	defaultNet, err := daemon.networks.GetNetwork(netid)
 	if err != nil {
 		return nil, err
 	}
 
 	// Retrieve the Sandbox corresponding to the starting container.
-	sandbox, err := daemon.extensions.Sandboxes().Get(core.DID(cid))
+	sandbox, err := daemon.sandboxes.Get(core.DID(cid))
 	if err != nil {
 		return nil, err
 	}

--- a/daemon/list.go
+++ b/daemon/list.go
@@ -91,7 +91,7 @@ func (daemon *Daemon) Containers(job *engine.Job) engine.Status {
 		var nameMatch bool
 		for _, endpoints := range container.Endpoints {
 			for _, epid := range endpoints {
-				ep, err := daemon.extensions.Networks().GetEndpoint(epid)
+				ep, err := daemon.networks.GetEndpoint(epid)
 				if err != nil {
 					return err
 				}

--- a/daemon/net.go
+++ b/daemon/net.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"github.com/docker/docker/core"
 	"github.com/docker/docker/engine"
+	"github.com/docker/docker/network"
 )
 
 func (d *Daemon) CmdNetCreate(job *engine.Job) engine.Status {
@@ -12,7 +13,7 @@ func (d *Daemon) CmdNetCreate(job *engine.Job) engine.Status {
 
 	// FIXME What do we do with user provided name?
 	// Store in Service? Store in NetController?
-	netw, err := d.extensions.Networks().NewNetwork()
+	netw, err := d.networks.NewNetwork()
 	if err != nil {
 		return job.Error(err)
 	}
@@ -21,7 +22,7 @@ func (d *Daemon) CmdNetCreate(job *engine.Job) engine.Status {
 }
 
 func (d *Daemon) CmdNetLs(job *engine.Job) engine.Status {
-	netw := d.extensions.Networks().ListNetworks()
+	netw := d.networks.ListNetworks()
 	table := engine.NewTable("Name", len(netw))
 	for _, netid := range netw {
 		item := &engine.Env{}
@@ -39,7 +40,7 @@ func (d *Daemon) CmdNetRm(job *engine.Job) engine.Status {
 		return job.Errorf("usage: %s NAME", job.Name)
 	}
 
-	if err := d.extensions.Networks().RemoveNetwork(core.DID(job.Args[0])); err != nil {
+	if err := d.networks.RemoveNetwork(core.DID(job.Args[0])); err != nil {
 		return job.Error(err)
 	}
 	return engine.StatusOK
@@ -50,14 +51,14 @@ func (d *Daemon) CmdNetJoin(job *engine.Job) engine.Status {
 		return job.Errorf("usage: %s NETWORK CONTAINER NAME", job.Name)
 	}
 
-	net, err := d.extensions.Networks().GetNetwork(core.DID(job.Args[0]))
+	net, err := d.networks.GetNetwork(core.DID(job.Args[0]))
 	if err != nil {
 		return job.Error(err)
 	}
 
 	// FIXME The provided CONTAINER could be the 'user facing ID'. but not
 	// necessarily the sandbox ID itself: we're keeping things simple herengine.
-	sandbox, err := d.extensions.Sandboxes().Get(core.DID(job.Args[1]))
+	sandbox, err := d.sandboxes.Get(core.DID(job.Args[1]))
 	if err != nil {
 		return job.Error(err)
 	}
@@ -73,7 +74,7 @@ func (d *Daemon) CmdNetLeave(job *engine.Job) engine.Status {
 		return job.Errorf("usage: %s NETWORK NAME", job.Name)
 	}
 
-	net, err := d.extensions.Networks().GetNetwork(core.DID(job.Args[0]))
+	net, err := d.networks.GetNetwork(core.DID(job.Args[0]))
 	if err != nil {
 		return job.Error(err)
 	}
@@ -100,4 +101,13 @@ func (d *Daemon) CmdNetExport(job *engine.Job) engine.Status {
 	}
 	// FIXME
 	return engine.StatusOK
+}
+
+func (d *Daemon) RegisterNetworkDriver(driver network.Driver, name string) error {
+	return d.networks.AddDriver(driver, name)
+}
+
+func (d *Daemon) UnregisterNetworkDriver(name string) error {
+	// FIXME Forward to d.networks
+	return nil
 }

--- a/extensions/builtins.go
+++ b/extensions/builtins.go
@@ -1,0 +1,110 @@
+package extensions
+
+import (
+	"fmt"
+
+	"github.com/docker/docker/extensions/context"
+	"github.com/docker/docker/network"
+	"github.com/docker/docker/state"
+)
+
+type ExtensionBuilder func() Extension
+
+// The table of all "compiled-in" extensions: their names are hardcoded, and
+// name resolution is achieved with a simple map lookup.
+var builtinExtensions = map[string]ExtensionBuilder{}
+
+func RegisterBuiltin(name string, builder ExtensionBuilder) error {
+	if _, ok := builtinExtensions[name]; ok {
+		return fmt.Errorf("builtin extension %q is already registered", name)
+	}
+
+	builtinExtensions[name] = builder
+	return nil
+}
+
+func newBuiltinExtension(name string, controller *Controller, state state.State) (Extension, error) {
+	extBuilder, ok := builtinExtensions[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown builtin extension %q", name)
+	}
+
+	return &builtinExtension{
+		controller: controller,
+		extension:  extBuilder(),
+		state:      state,
+	}, nil
+}
+
+type builtinExtension struct {
+	controller *Controller
+	extension  Extension
+	state      state.State
+}
+
+func (e *builtinExtension) newContext(parentCtx context.Context) (context.Context, error) {
+	scope, err := e.state.Scope("/config")
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := &builtinContext{
+		Context:    parentCtx,
+		controller: e.controller,
+		extension:  e.extension,
+		state:      e.state,
+		config:     scope,
+	}
+
+	return ctx, nil
+}
+
+func (e *builtinExtension) Install(parentCtx context.Context) error {
+	return e.dispatchWithContext(parentCtx, e.extension.Install)
+}
+
+func (e *builtinExtension) Uninstall(parentCtx context.Context) error {
+	return e.dispatchWithContext(parentCtx, e.extension.Uninstall)
+}
+
+func (e *builtinExtension) Disable(parentCtx context.Context) error {
+	return e.dispatchWithContext(parentCtx, e.extension.Disable)
+}
+
+func (e *builtinExtension) Enable(parentCtx context.Context) error {
+	return e.dispatchWithContext(parentCtx, e.extension.Enable)
+}
+
+func (e *builtinExtension) dispatchWithContext(parentCtx context.Context, fn func(context.Context) error) error {
+	if scopedCtx, err := e.newContext(parentCtx); err != nil {
+		return err
+	} else {
+		return fn(scopedCtx)
+	}
+}
+
+// builtinContext exposes the core-facing side of a Context.
+type builtinContext struct {
+	context.Context
+	extension  Extension
+	controller *Controller
+
+	state  state.State
+	config state.State
+}
+
+func (ctx *builtinContext) MyState() state.State {
+	return ctx.state
+}
+
+func (ctx *builtinContext) MyConfig() state.State {
+	return ctx.config
+}
+
+func (ctx *builtinContext) RegisterNetworkDriver(driver network.Driver, name string) error {
+	return ctx.controller.core.RegisterNetworkDriver(driver, name)
+}
+
+func (ctx *builtinContext) UnregisterNetworkDriver(name string) error {
+	return ctx.controller.core.UnregisterNetworkDriver(name)
+}

--- a/extensions/context/context.go
+++ b/extensions/context/context.go
@@ -1,0 +1,49 @@
+package context
+
+import (
+	"github.com/docker/docker/network"
+	"github.com/docker/docker/state"
+)
+
+type Core interface {
+	RegisterNetworkDriver(driver network.Driver, name string) error
+	UnregisterNetworkDriver(name string) error
+}
+
+// Additionnally to providing a scoped context, Context implements all the
+// necessary methods for interacting with Docker core facilities.
+type Context interface {
+	Core
+
+	MyState() state.State
+	MyConfig() state.State
+}
+
+type emptyContext int
+
+func (*emptyContext) MyState() state.State {
+	return nil
+}
+
+func (*emptyContext) MyConfig() state.State {
+	return nil
+}
+
+func (*emptyContext) Done() <-chan struct{} {
+	return nil
+}
+
+func (*emptyContext) RegisterNetworkDriver(driver network.Driver, name string) error {
+	return nil
+}
+
+func (*emptyContext) UnregisterNetworkDriver(name string) error {
+	return nil
+}
+
+var rootContext = new(emptyContext)
+
+// This is called `Background` in Google's package.
+func Root() Context {
+	return rootContext
+}

--- a/extensions/simplebridge/extension.go
+++ b/extensions/simplebridge/extension.go
@@ -1,12 +1,10 @@
 package simplebridge
 
-import (
-	"github.com/docker/docker/extensions"
-)
+import "github.com/docker/docker/extensions/context"
 
 type Extension struct{}
 
-func (e Extension) Install(c extensions.Context) error   { return nil }
-func (e Extension) Uninstall(c extensions.Context) error { return nil }
-func (e Extension) Enable(c extensions.Context) error    { return nil }
-func (e Extension) Disable(c extensions.Context) error   { return nil }
+func (e Extension) Install(c context.Context) error   { return nil }
+func (e Extension) Uninstall(c context.Context) error { return nil }
+func (e Extension) Enable(c context.Context) error    { return nil }
+func (e Extension) Disable(c context.Context) error   { return nil }

--- a/extensions/system.go
+++ b/extensions/system.go
@@ -1,20 +1,6 @@
 package extensions
 
-import (
-	"github.com/docker/docker/network"
-	"github.com/docker/docker/state"
-)
-
-type Context interface {
-	//context.Context // FIXME get to compile
-
-	MyState() state.State
-	MyConfig() state.State
-
-	RegisterNetworkDriver(driver network.Driver, name string) error
-	UnregisterNetworkDriver(name string) error
-	Log(msg string)
-}
+import "github.com/docker/docker/extensions/context"
 
 // An extension is a object which can extend the capabilities of Docker by
 // hooking into various points of its lifecycle: networking, storage, sandboxing,
@@ -27,12 +13,12 @@ type Extension interface {
 	// Once installed the extension must be enabled separately. Install MUST NOT
 	// interfere with the functioning and user experience of Docker.
 	//
-	Install(c Context) error
+	Install(c context.Context) error
 
 	// Uninstall is called when the extension is uninstalled.
 	// The extension should use it to tear down resources initialized at install,
 	// and cleaning up the host environment of any side effects.
-	Uninstall(c Context) error
+	Uninstall(c context.Context) error
 
 	// Enable is called when a) the user enables the extension, or b) the daemon is starting
 	// and the extension is already enabled.
@@ -40,8 +26,8 @@ type Extension interface {
 	// The extension should use it to hook itself into the core to modify its behavior.
 	// See the Core interface for available interactions with the core.
 	//
-	Enable(c Context) error
+	Enable(c context.Context) error
 
 	// Disabled is called when the extension is disabled.
-	Disable(c Context) error
+	Disable(c context.Context) error
 }

--- a/network/controller.go
+++ b/network/controller.go
@@ -29,7 +29,7 @@ func NewController(s state.State) *Controller {
 }
 
 // FIXME:networking
-func (c *Controller) AddDriver(driver Driver) error {
+func (c *Controller) AddDriver(driver Driver, name string) error {
 	c.driver = driver
 	return nil
 }

--- a/sandbox/controller.go
+++ b/sandbox/controller.go
@@ -8,7 +8,7 @@ import (
 	"github.com/docker/docker/state"
 )
 
-func NewController() *Controller {
+func NewController(s state.State) *Controller {
 	return &Controller{}
 }
 


### PR DESCRIPTION
This takes on @shykes last commit to continue extensions management and `Context` providing to loaded extensions. I tried my best to push things forwards while building on the changes introduced by d8e536ad1d4a6, but tbh I don't understand them all so I hope the result makes sense.

The good news: it builds. The bad news: it crashes at daemon initialization as more and more code is now relying on `state.Scope()` (which is not yet implemented in `GitState`).

What still seems to be missing for a running daemon:
- Implementation of `extensions.state.GitState.Scope()`
- Implementation of `extension.simplebridge.Controller` which registers the driver
- Implementation of `sandbox` to give the driver somewhere to put its shiny network interfaces
