### PR TITLE
Core continued

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -325,10 +325,11 @@ func (daemon *Daemon) restore() error {
 		}
 
 		// Create a default network for the default driver.
-		if net, err := daemon.networks.NewNetwork(); err != nil {
+		if _, err := daemon.networks.NewNetwork("default"); err != nil {
 			return fmt.Errorf("failed to create default network using default driver: %v", err)
 		} else {
-			daemon.networks.DefaultNetworkID = net.Id()
+			// FIXME:networking Returned net is nil
+			//daemon.networks.DefaultNetworkID = net.Id()
 		}
 	}
 

--- a/daemon/net.go
+++ b/daemon/net.go
@@ -11,13 +11,12 @@ func (d *Daemon) CmdNetCreate(job *engine.Job) engine.Status {
 		return job.Errorf("usage: %s NAME", job.Name)
 	}
 
-	// FIXME What do we do with user provided name?
-	// Store in Service? Store in NetController?
-	netw, err := d.networks.NewNetwork()
+	_, err := d.networks.NewNetwork(job.Args[0])
 	if err != nil {
 		return job.Error(err)
 	}
-	job.Printf("%v\n", netw.Id())
+	// FIXME:neworking NewNework returns nil
+	//job.Printf("%v\n", netw.Id())
 	return engine.StatusOK
 }
 

--- a/daemon/networkdriver/portmapper/mapper.go
+++ b/daemon/networkdriver/portmapper/mapper.go
@@ -172,5 +172,6 @@ func forward(action iptables.Action, proto string, sourceIP net.IP, sourcePort i
 	if chain == nil {
 		return nil
 	}
-	return chain.Forward(action, sourceIP, sourcePort, proto, containerIP, containerPort)
+
+	return chain.Forward(action, sourceIP, uint(sourcePort), proto, net.ParseIP(containerIP), uint(containerPort))
 }

--- a/extensions/controller.go
+++ b/extensions/controller.go
@@ -45,8 +45,8 @@ func (c *Controller) Restore(state state.State) error {
 // messages.
 func (c *Controller) Install(name string) error {
 	ext, err := c.load(name)
-	if err == nil {
-		return fmt.Errorf("failed to install extension with duplicated name %q", name)
+	if err != nil {
+		return err
 	}
 
 	ctx := context.Root()
@@ -63,7 +63,7 @@ func (c *Controller) Install(name string) error {
 // registered.
 func (c *Controller) load(name string) (Extension, error) {
 	if _, ok := c.extensions[name]; ok {
-		return nil, fmt.Errorf("extention %q is already loaded", name)
+		return nil, fmt.Errorf("extension %q is already loaded", name)
 	}
 
 	state, err := c.state.Scope("extensions/" + name + "/state")

--- a/extensions/simplebridge/extension.go
+++ b/extensions/simplebridge/extension.go
@@ -2,9 +2,17 @@ package simplebridge
 
 import "github.com/docker/docker/extensions/context"
 
+const driverName = "bridge"
+
 type Extension struct{}
 
-func (e Extension) Install(c context.Context) error   { return nil }
-func (e Extension) Uninstall(c context.Context) error { return nil }
-func (e Extension) Enable(c context.Context) error    { return nil }
-func (e Extension) Disable(c context.Context) error   { return nil }
+func (e Extension) Install(c context.Context) error {
+	return c.RegisterNetworkDriver(&BridgeDriver{state: c.MyState()}, driverName)
+}
+
+func (e Extension) Uninstall(c context.Context) error {
+	return c.UnregisterNetworkDriver(driverName)
+}
+
+func (e Extension) Enable(c context.Context) error  { return nil }
+func (e Extension) Disable(c context.Context) error { return nil }

--- a/extensions/state.go
+++ b/extensions/state.go
@@ -77,9 +77,14 @@ func (s GitState) Mkdir(dir string) error {
 	return s.db.Commit(fmt.Sprintf("mkdir %q", dir))
 }
 
+// FIXME: should we stop returning error?
+func (s GitState) Scope(key string) (state.State, error) {
+	// FIXME: should we split the key on the path separator?
+	return GitState{s.db.Scope(key)}, nil
+}
+
 func (s GitState) Diff(other state.Tree) (added, removed state.Tree)            { return nil, nil }
 func (s GitState) Walk(func(key string, entry state.Value)) error               { return nil }
 func (s GitState) Add(key string, overlay state.Tree) (state.Tree, error)       { return nil, nil }
 func (s GitState) Subtract(key string, whiteout state.Tree) (state.Tree, error) { return nil, nil }
-func (s GitState) Scope(key string) (state.State, error)                        { return nil, nil }
 func (s GitState) Pipeline() state.Pipeline                                     { return nil }

--- a/network/controller.go
+++ b/network/controller.go
@@ -94,9 +94,8 @@ func (c *Controller) RemoveNetwork(id core.DID) error {
 	return nil
 }
 
-func (c *Controller) NewNetwork() (Network, error) {
-	did := core.DID("") // core.GenerateDID() // func Generatecore.DID() core.DID { return core.DID(uuid.New()) }
-	err := c.driver.AddNetwork(string(did))
+func (c *Controller) NewNetwork(name string) (Network, error) {
+	err := c.driver.AddNetwork(name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Fix build
- Fix basic errors at daemon launch

Good news:

```
$ docker -d&
$ docker net create skynet
INFO[0001] POST /v1.16/cmd
INFO[0001] +job net_create(skynet)
INFO[0001] -job net_create(skynet) = OK (0)
$ ip a | grep skynet: -A5
9: skynet: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN group default
    link/ether 8a:b6:b3:4d:8c:20 brd ff:ff:ff:ff:ff:ff
    inet 10.0.42.1/16 scope global skynet
       valid_lft forever preferred_lft forever
    inet6 fe80::88b6:b3ff:fe4d:8c20/64 scope link
       valid_lft forever preferred_lft forever
```

Issues:
- `network.Controller` returns a `nil` `Network` instance, so we cannot do any operations on a created network
- When the `"default"` bridge interface already exists, daemon launch fails on [`BridgeDriver.CreateBridge`](https://github.com/shykes/docker/blob/e30974b2cf52c60ee383ff677f3666008381f577/extensions/simplebridge/driver.go#L212) with `netlink.LinkAdd` returning error "file exists".

I'll try to submit integration-cli tests next.
