### PR TITLE
Nets fixes

### DIFF
--- a/daemon/net.go
+++ b/daemon/net.go
@@ -10,21 +10,23 @@ func (d *Daemon) CmdNetCreate(job *engine.Job) engine.Status {
 		return job.Errorf("usage: %s NAME", job.Name)
 	}
 
-	_, err := d.networks.NewNetwork(job.Args[0])
+	thisNet, err := d.networks.NewNetwork(job.Args[0])
 	if err != nil {
 		return job.Error(err)
 	}
-	// FIXME:neworking NewNework returns nil
-	//job.Printf("%v\n", netw.Id())
+
+	job.Printf("%v\n", thisNet.Id())
 	return engine.StatusOK
 }
 
 func (d *Daemon) CmdNetLs(job *engine.Job) engine.Status {
 	netw := d.networks.ListNetworks()
+
 	table := engine.NewTable("Name", len(netw))
 	for _, netid := range netw {
 		item := &engine.Env{}
-		item.Set("ID", netid)
+		item.Set("Name", netid)
+		table.Add(item)
 	}
 
 	if _, err := table.WriteTo(job.Stdout); err != nil {

--- a/extensions/simplebridge/driver.go
+++ b/extensions/simplebridge/driver.go
@@ -227,6 +227,7 @@ func (d *BridgeDriver) createBridge(id string) (*BridgeNetwork, error) {
 		return nil, err
 	}
 
+	// DEMO FIXME
 	vxlan := &netlink.Vxlan{
 		LinkAttrs: netlink.LinkAttrs{Name: "vx" + id[0:4]},
 		VxlanId:   42,
@@ -257,4 +258,13 @@ func (d *BridgeDriver) createBridge(id string) (*BridgeNetwork, error) {
 		network:     addr,
 		ipallocator: NewIPAllocator(id, addr, nil, nil),
 	}, nil
+}
+
+func (d *BridgeDriver) destroyBridge(b *netlink.Bridge, v *netlink.Vxlan) error {
+	// DEMO FIXME
+	if err := netlink.LinkDel(v); err != nil {
+		return err
+	}
+
+	return netlink.LinkDel(b)
 }

--- a/extensions/simplebridge/driver.go
+++ b/extensions/simplebridge/driver.go
@@ -168,7 +168,7 @@ func (d *BridgeDriver) loadNetwork(id string) (*BridgeNetwork, error) {
 
 	return &BridgeNetwork{
 		// DEMO FIXME
-		vxlan:       &netlink.Vxlan{LinkAttrs: netlink.LinkAttrs{Name: "vx" + iface[0:4]}},
+		vxlan:       &netlink.Vxlan{LinkAttrs: netlink.LinkAttrs{Name: "vx" + iface}},
 		bridge:      &netlink.Bridge{LinkAttrs: netlink.LinkAttrs{Name: iface}},
 		ID:          id,
 		driver:      d,
@@ -229,7 +229,7 @@ func (d *BridgeDriver) createBridge(id string) (*BridgeNetwork, error) {
 
 	// DEMO FIXME
 	vxlan := &netlink.Vxlan{
-		LinkAttrs: netlink.LinkAttrs{Name: "vx" + id[0:4]},
+		LinkAttrs: netlink.LinkAttrs{Name: "vx" + id},
 		VxlanId:   42,
 		Group:     net.ParseIP("239.1.1.1"),
 		Port:      1234,

--- a/extensions/simplebridge/network.go
+++ b/extensions/simplebridge/network.go
@@ -43,10 +43,5 @@ func (b *BridgeNetwork) Unlink(name string) error {
 }
 
 func (b *BridgeNetwork) destroy() error {
-	// DEMO FIXME
-	if err := netlink.LinkDel(b.vxlan); err != nil {
-		return err
-	}
-
-	return netlink.LinkDel(b.bridge)
+	return b.driver.destroyBridge(b.bridge, b.vxlan)
 }

--- a/network/controller.go
+++ b/network/controller.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/docker/docker/sandbox"
@@ -94,16 +95,20 @@ func (c *Controller) RemoveNetwork(id string) error {
 }
 
 func (c *Controller) NewNetwork(name string) (Network, error) {
-	err := c.driver.AddNetwork(name)
-	if err != nil {
+	if err := c.driver.AddNetwork(name); err != nil {
 		return nil, err
 	}
 
 	c.mutex.Lock()
-	//c.networks[did] = net
-	c.mutex.Unlock()
+	defer c.mutex.Unlock()
+	thisNet, err := c.driver.GetNetwork(name)
+	if err != nil {
+		return nil, err
+	}
+	c.networks[name] = thisNet
+	fmt.Println(c.networks)
 
-	return nil, nil
+	return thisNet, nil
 }
 
 func (c *Controller) GetEndpoint(id string) (Endpoint, error) {


### PR DESCRIPTION
This fixes `nets ls` (and the zero-arg form) and `nets rm`.

NOTE: because of the vxlan issues that I will fix later today (revolving around state and parameter passing), you will have to `ip link del vxdefault` to be able to successfully create and rm networks. The functionality works, the driver just needs to be tweaked a bit to handle peering appropriately.
