### PR TITLE
Parameter passing

### DIFF
--- a/api/client/commands.go
+++ b/api/client/commands.go
@@ -2723,18 +2723,14 @@ func (cli *DockerCli) CmdNets(args ...string) error {
 func (cli *DockerCli) CmdNetsCreate(args ...string) error {
 	cmd := cli.Subcmd("nets create", "NAME", "Create a network")
 
-	if err := cmd.Parse(args); err != nil {
-		return err
-	}
-
-	if cmd.NArg() != 1 {
+	if len(args) < 1 {
 		cmd.Usage()
 		return nil
 	}
 
 	apiCmd := &api.Cmd{
 		Name: "net_create",
-		Args: cmd.Args(),
+		Args: args,
 	}
 
 	if _, _, err := cli.call("POST", "/cmd", apiCmd, true); err != nil {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -326,7 +326,8 @@ func (daemon *Daemon) restore() error {
 		}
 
 		// Create a default network for the default driver.
-		if _, err := daemon.networks.NewNetwork("default"); err != nil {
+		// FIXME should take parameters from docker -d
+		if _, err := daemon.networks.NewNetwork("default", []string{}); err != nil {
 			return fmt.Errorf("failed to create default network using default driver: %v", err)
 		} else {
 			// FIXME:networking Returned net is nil

--- a/daemon/net.go
+++ b/daemon/net.go
@@ -6,11 +6,17 @@ import (
 )
 
 func (d *Daemon) CmdNetCreate(job *engine.Job) engine.Status {
-	if len(job.Args) != 1 {
+	if len(job.Args) < 1 {
 		return job.Errorf("usage: %s NAME", job.Name)
 	}
 
-	thisNet, err := d.networks.NewNetwork(job.Args[0])
+	params := []string{}
+
+	if len(job.Args) > 1 {
+		params = job.Args[1:]
+	}
+
+	thisNet, err := d.networks.NewNetwork(job.Args[0], params)
 	if err != nil {
 		return job.Error(err)
 	}

--- a/extensions/simplebridge/driver.go
+++ b/extensions/simplebridge/driver.go
@@ -169,7 +169,7 @@ func (d *BridgeDriver) loadNetwork(id string) (*BridgeNetwork, error) {
 
 	return &BridgeNetwork{
 		// DEMO FIXME
-		vxlan:       &netlink.Vxlan{LinkAttrs: netlink.LinkAttrs{Name: "vx" + iface}},
+		//vxlan:       &netlink.Vxlan{LinkAttrs: netlink.LinkAttrs{Name: "vx" + iface}},
 		bridge:      &netlink.Bridge{LinkAttrs: netlink.LinkAttrs{Name: iface}},
 		ID:          id,
 		driver:      d,
@@ -244,7 +244,6 @@ func (d *BridgeDriver) createBridge(id string, vlanid uint, port uint, peer stri
 	var vxlan *netlink.Vxlan
 
 	if peer != "" {
-		fmt.Println(peer)
 		vxlan = &netlink.Vxlan{
 			// DEMO FIXME: name collisions, better error recovery
 			LinkAttrs: netlink.LinkAttrs{Name: "vx" + id},
@@ -281,8 +280,10 @@ func (d *BridgeDriver) createBridge(id string, vlanid uint, port uint, peer stri
 
 func (d *BridgeDriver) destroyBridge(b *netlink.Bridge, v *netlink.Vxlan) error {
 	// DEMO FIXME
-	if err := netlink.LinkDel(v); err != nil {
-		return err
+	if v != nil {
+		if err := netlink.LinkDel(v); err != nil {
+			return err
+		}
 	}
 
 	return netlink.LinkDel(b)

--- a/extensions/simplebridge/driver_test.go
+++ b/extensions/simplebridge/driver_test.go
@@ -10,10 +10,6 @@ import (
 )
 
 func createNetwork(t *testing.T) *BridgeDriver {
-	if link, err := netlink.LinkByName("vxtest"); err == nil {
-		netlink.LinkDel(link)
-	}
-
 	if link, err := netlink.LinkByName("test"); err == nil {
 		netlink.LinkDel(link)
 	}
@@ -34,7 +30,7 @@ func createNetwork(t *testing.T) *BridgeDriver {
 		t.Fatal(err)
 	}
 
-	if err := driver.AddNetwork("test"); err != nil {
+	if err := driver.AddNetwork("test", []string{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -56,24 +52,12 @@ func TestNetwork(t *testing.T) {
 		t.Fatalf("Could not find %q link", "test")
 	}
 
-	// DEMO FIXME
-
-	if link, _ := netlink.LinkByName("vxtest"); link == nil {
-		t.Fatalf("Could not find %q link", "vxtest")
-	}
-
 	if err := driver.RemoveNetwork("test"); err != nil {
 		t.Fatal(err)
 	}
 
 	if link, _ := netlink.LinkByName("test"); link != nil {
 		t.Fatalf("link %q still exists after RemoveNetwork", "test")
-	}
-
-	// DEMO FIXME
-
-	if link, _ := netlink.LinkByName("vxtest"); link != nil {
-		t.Fatalf("link %q still exists after RemoveNetwork", "vxtest")
 	}
 }
 

--- a/network/controller.go
+++ b/network/controller.go
@@ -1,7 +1,6 @@
 package network
 
 import (
-	"fmt"
 	"sync"
 
 	"github.com/docker/docker/sandbox"
@@ -94,8 +93,8 @@ func (c *Controller) RemoveNetwork(id string) error {
 	return nil
 }
 
-func (c *Controller) NewNetwork(name string) (Network, error) {
-	if err := c.driver.AddNetwork(name); err != nil {
+func (c *Controller) NewNetwork(name string, args []string) (Network, error) {
+	if err := c.driver.AddNetwork(name, args); err != nil {
 		return nil, err
 	}
 
@@ -106,7 +105,6 @@ func (c *Controller) NewNetwork(name string) (Network, error) {
 		return nil, err
 	}
 	c.networks[name] = thisNet
-	fmt.Println(c.networks)
 
 	return thisNet, nil
 }

--- a/network/driver.go
+++ b/network/driver.go
@@ -7,7 +7,7 @@ import (
 
 type Driver interface {
 	Restore(netstate state.State) error
-	AddNetwork(netid string) error
+	AddNetwork(netid string, params []string) error
 	RemoveNetwork(netid string) error
 	GetNetwork(id string) (Network, error)
 


### PR DESCRIPTION
This continues my other patches and adds parameter passing. This now works:

`docker nets create test --peer 123.123.123.123 --vid 42 --port 1234` for establishing vxlan tunnels.
